### PR TITLE
refactor: migrate PatternMonitor to useSelect/useDispatch hooks (-25 LOC)

### DIFF
--- a/src/components/pattern-monitor/index.js
+++ b/src/components/pattern-monitor/index.js
@@ -4,66 +4,41 @@
  */
 
 import { useEffect, useRef } from '@wordpress/element';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 
 /** @typedef {import('../../index').BlockEditorSettings} BlockEditorSettings */
 /** @typedef {import('../../store/editor/reducer').Pattern} Pattern */
 
 /**
- * Update callback
- *
- * @callback OnUpdate
- * @param {object[]} blocks - Editor content to save
- */
-
-/**
  * Sets up Gutenberg and the Isolated Block Editor
  *
- * An initial setup is performed, and is then reset each time the editor is focussed. This ensures we are applying the right
- * settings for this particular editor.
- *
- * @param {Object} props - Component props
- * @param {BlockEditorSettings} props.settings - Settings
- * @param {Pattern} props.currentPattern - Currently selected pattern
- * @param {OnUpdate} props.updateBlocksWithoutUndo - Callback to update blocks
+ * An initial setup is performed, and is then reset each time the editor is
+ * focussed. This ensures we are applying the right settings for this
+ * particular editor.
  */
-function PatternMonitor( props ) {
-	const { currentPattern, updateBlocksWithoutUndo } = props;
+export default function PatternMonitor() {
+	const currentPattern = useSelect(
+		// @ts-ignore
+		( select ) => select( 'isolated/editor' ).getCurrentPattern(),
+		[]
+	);
+	// @ts-ignore
+	const { updateBlocksWithoutUndo } = useDispatch( 'isolated/editor' );
 	const previous = useRef( null );
 
 	// Monitor the current pattern and update the editor content if it changes
 	useEffect( () => {
 		if ( currentPattern === null || previous.current === currentPattern ) {
-			// @ts-ignore
 			previous.current = currentPattern;
 			return;
 		}
 
-		// @ts-ignore
 		previous.current = currentPattern.name;
 		setTimeout( () => {
 			updateBlocksWithoutUndo( parse( currentPattern.content ) );
 		}, 0 );
-	}, [ currentPattern ] );
+	}, [ currentPattern, updateBlocksWithoutUndo ] );
 
 	return null;
 }
-
-export default compose( [
-	withSelect( ( select ) => {
-		const { getCurrentPattern } = select( 'isolated/editor' );
-
-		return {
-			currentPattern: getCurrentPattern(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { updateBlocksWithoutUndo } = dispatch( 'isolated/editor' );
-
-		return {
-			updateBlocksWithoutUndo,
-		};
-	} ),
-] )( PatternMonitor );


### PR DESCRIPTION
## Summary

First in the **HoC → hooks** migration series tracked by #9. Migrates `src/components/pattern-monitor/index.js` from `compose([withSelect, withDispatch])` to direct `useSelect` + `useDispatch` calls.

Refs #9. Part of #2.

## Why this one first

`PatternMonitor` is the smallest leaf-component candidate:

- 69 LOC before, 43 LOC after
- Single consumer (`<PatternMonitor />` in `src/index.js`)
- Takes no external props — pure store reader
- No tests reference it directly (verified via grep)

If anything goes sideways with the migration pattern, this is the lowest-blast-radius file to validate it on.

## Behavior preservation

The pre-existing ref-tracking quirk is preserved verbatim:

- On the `null` / unchanged branch, `previous.current` is set to `currentPattern` (the pattern object or null)
- On the change branch, `previous.current` is set to `currentPattern.name` (a string)

This means the equality check `previous.current === currentPattern` can mismatch types between renders. **That's a pre-existing behavior** — this PR does not silently fix it. If we want to clean it up, that's a separate change with a clear commit message.

The `useEffect` deps now include `updateBlocksWithoutUndo` (the dispatcher), per modern hooks rules.

## Diff stats

` ` ` text
1 file changed, 13 insertions(+), 38 deletions(-)
` ` `

## Verification

- [x] `babel --presets=@wordpress/babel-preset-default` transpiles cleanly
- [x] No tests reference `PatternMonitor` or its store interactions
- [ ] CI passes
- [ ] Manual smoke test: open editor, switch patterns via the pattern picker, confirm content swaps

## Pattern for future HoC migrations

This PR establishes the migration template. The remaining 17 files in #9 can follow the same shape:

` ` ` js
// Before
export default compose([
  withSelect((select) => ({ x: select('store').getX() })),
  withDispatch((dispatch) => ({ y: dispatch('store').y })),
])(MyComponent);

// After
export default function MyComponent() {
  const x = useSelect((select) => select('store').getX(), []);
  const { y } = useDispatch('store');
  // ...
}
` ` `

Files that take props from outside (most of the remaining 17) will need a thin functional wrapper instead of the default-export shape, but the data subscription pattern is identical.

## Related

- Epic: #2 (modernize IBE against current `@wordpress/editor` APIs)
- Tracking issue: #9 (HoC → hooks migration)