### PR TITLE
refactor: migrate HotSwapper to useRegistry/useSelect hooks

### DIFF
--- a/src/components/block-editor-container/hot-swapper.js
+++ b/src/components/block-editor-container/hot-swapper.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { withDispatch, withSelect } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useRegistry, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -10,32 +9,27 @@ import { useEffect } from '@wordpress/element';
  */
 import storeHotSwapPlugin from '../../store/plugins/store-hot-swap';
 
-function HotSwapper( { isEditing, hotSwap } ) {
+/**
+ * Routes wp.data access for `core/block-editor` and `core/editor` to the
+ * focused editor instance's sub-registry. Without this, blocks that call
+ * `wp.data.select( 'core/block-editor' )` directly would always read from
+ * the parent registry and ignore the per-instance editor state.
+ */
+export default function HotSwapper() {
+	const registry = useRegistry();
+	const isEditing = useSelect(
+		// @ts-ignore
+		( select ) => select( 'isolated/editor' ).isEditing(),
+		[]
+	);
+
 	useEffect( () => {
-		hotSwap( isEditing );
-	}, [ isEditing ] );
+		storeHotSwapPlugin.resetEditor();
+
+		if ( isEditing ) {
+			storeHotSwapPlugin.setEditor( registry.select, registry.dispatch );
+		}
+	}, [ isEditing, registry ] );
 
 	return null;
 }
-
-// @ts-ignore
-export default compose( [
-	withSelect( ( select ) => {
-		const { isEditing } = select( 'isolated/editor' );
-
-		return {
-			isEditing: isEditing(),
-		};
-	} ),
-	withDispatch( ( dispatch, ownProps, { select } ) => {
-		return {
-			hotSwap: ( isEditing ) => {
-				storeHotSwapPlugin.resetEditor();
-
-				if ( isEditing ) {
-					storeHotSwapPlugin.setEditor( select, dispatch );
-				}
-			},
-		};
-	} ),
-] )( HotSwapper );


### PR DESCRIPTION
## Summary

Continues the **HoC → hooks** migration tracked by #9. Migrates `src/components/block-editor-container/hot-swapper.js` from `compose([withSelect, withDispatch])` to `useRegistry` + `useSelect`.

> **Branch naming note:** the branch is named `hoc-footer` because the original plan was to migrate `footer.js` next. On opening the file, `footer.js` turned out to already use hooks — only the `compose` package import was matched by the original sweep, not the `compose` HoC. See "Issue #9 correction" below.

Refs #9. Part of #2.

## What's special about this one

`HotSwapper` drives the focus-routing store plugin (`storeHotSwapPlugin`). It needs **the registry-bound `select` and `dispatch` functions** — not the helpers from `useSelect`/`useDispatch`, which are scoped to a specific store. The HoC version got these from `withDispatch`'s third-argument helper:

` ` ` js
withDispatch( ( dispatch, ownProps, { select } ) => ({
  hotSwap: () => storeHotSwapPlugin.setEditor( select, dispatch ),
}))
` ` `

The hooks equivalent is `useRegistry()` which returns the registry from `RegistryProvider` context. `registry.select` and `registry.dispatch` are the same shape (key → store-namespace) the plugin's `targetSelect`/`targetDispatch` require.

Verified: `useRegistry` reads from the **sub-registry** when called inside an `IsolatedBlockEditor` instance (because `RegistryProvider` wraps it via `withRegistryProvider`). Same registry the HoC version was using.

## Diff stats

` ` ` text
1 file changed, 21 insertions(+), 27 deletions(-)
` ` `

Net: -8 LOC. Also adds a docblock explaining what `HotSwapper` exists to do — the original had no comment.

## Verification

- [x] `babel --presets=@wordpress/babel-preset-default` transpiles cleanly
- [ ] CI passes
- [ ] Manual smoke test: open multiple IBE instances on the same page, type in one, confirm typing routes to the focused editor's content (not the unfocused one)

## Issue #9 correction

The original sweep reported 18 files using legacy HoC composition. Re-running with `\bwithSelect\b|\bwithDispatch\b` (excluding the false-positive `compose` package imports) yields **9 files** total:

- ✅ `pattern-monitor/index.js` — PR #14
- ✅ `block-editor-container/hot-swapper.js` — **this PR**
- ⏳ `block-editor-container/index.js`
- ⏳ `block-editor-contents/index.js`
- ⏳ `block-editor/index.js`
- ⏳ `block-editor/post-text-editor.js` (resolved by #5 if we adopt EditorProvider via #7)
- ⏳ `block-editor-toolbar/more-menu/editor-menu.js`
- ⏳ `block-editor-toolbar/toggle-feature/index.js`
- ⏳ `block-editor-toolbar/toggle-option/index.js`

So 7 remain after this PR.

`with-registry-provider/index.js` uses `createHigherOrderComponent` because it IS an HoC factory — separate concern, lives under #3.

## Related

- Epic: #2 (modernize IBE against current `@wordpress/editor` APIs)
- Tracking issue: #9 (HoC → hooks migration)
- Adjacent context: `storeHotSwapPlugin` itself is on a deprecated wp.data store-plugin API — tracked separately in #8