### PR TITLE
fix: reset HotSwapper target on unmount

### DIFF
--- a/src/components/block-editor-container/hot-swapper.js
+++ b/src/components/block-editor-container/hot-swapper.js
@@ -25,10 +25,18 @@ export default function HotSwapper() {
 
 	useEffect( () => {
 		storeHotSwapPlugin.resetEditor();
+		let didSetEditor = false;
 
 		if ( isEditing ) {
 			storeHotSwapPlugin.setEditor( registry.select, registry.dispatch );
+			didSetEditor = true;
 		}
+
+		return () => {
+			if ( didSetEditor ) {
+				storeHotSwapPlugin.resetEditor();
+			}
+		};
 	}, [ isEditing, registry ] );
 
 	return null;


### PR DESCRIPTION
## Summary

Fixes the latent HotSwapper cleanup bug found during review of #15.

When a focused `IsolatedBlockEditor` unmounts, `storeHotSwapPlugin.targetSelect` / `targetDispatch` can keep pointing at that editor's disposed sub-registry. Future direct `wp.data.select( 'core/block-editor' )` calls can then route to stale state until another editor focuses and replaces the target.

Closes #16.

## What changed

Adds an effect cleanup to `HotSwapper` that resets the global hot-swap target **only if this effect actually set it**.

That guard matters for multi-instance pages: an unfocused editor unmounting should not clear another editor's active focus target.

## Why the cleanup is guarded

Naive cleanup would be:

```js
return () => {
    storeHotSwapPlugin.resetEditor();
};
```

But every `HotSwapper` instance runs the effect, including instances where `isEditing === false`. If an unfocused editor unmounted after another editor became focused, naive cleanup could clear the focused editor's target.

This PR tracks whether the current effect set the target:

```js
let didSetEditor = false;

if ( isEditing ) {
    storeHotSwapPlugin.setEditor( registry.select, registry.dispatch );
    didSetEditor = true;
}

return () => {
    if ( didSetEditor ) {
        storeHotSwapPlugin.resetEditor();
    }
};
```

## Verification

- [x] Babel transpiles `hot-swapper.js` cleanly
- [x] Diff is limited to `src/components/block-editor-container/hot-swapper.js`
- [ ] Manual smoke test: mount two editor instances, focus one, unmount it, confirm global `wp.data.select( 'core/block-editor' )` no longer routes to stale state

## Notes

This intentionally does **not** change the pre-existing behavior where each effect run starts with `storeHotSwapPlugin.resetEditor()`. That broader focus-order behavior existed before #15 and before this PR. This PR only fixes the unmount leak identified in #16.