### PR TITLE
fix: type HotSwapper registry access

### DIFF
--- a/src/components/block-editor-container/hot-swapper.js
+++ b/src/components/block-editor-container/hot-swapper.js
@@ -16,7 +16,9 @@ import storeHotSwapPlugin from '../../store/plugins/store-hot-swap';
  * the parent registry and ignore the per-instance editor state.
  */
 export default function HotSwapper() {
-	const registry = useRegistry();
+	const registry = /** @type {{ select: Function, dispatch: Function }} */ (
+		/** @type {unknown} */ ( useRegistry() )
+	);
 	const isEditing = useSelect(
 		// @ts-ignore
 		( select ) => select( 'isolated/editor' ).isEditing(),


### PR DESCRIPTION
## Summary

Fixes the `build:types` regression introduced by the HotSwapper hook migration.

`useRegistry()` is typed as `Function` in this JS/TS setup, but `HotSwapper` needs the registry object shape so it can pass `registry.select` and `registry.dispatch` to `storeHotSwapPlugin`.

This adds a narrow JSDoc cast instead of disabling type checking for the whole file.

## Verification

- [x] `npm run build:types` passes
- [x] Source-only diff limited to `src/components/block-editor-container/hot-swapper.js`

## Notes

The type build emitted `build-types/` changes locally because prior PRs updated source without regenerated type artifacts. Those generated files are intentionally **not** included here; this PR only fixes the source-level type error that blocks type generation.